### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/src/Pages/Overview.jsx
+++ b/src/Pages/Overview.jsx
@@ -144,7 +144,19 @@ const Overview = () => {
 						<ReactMarkdown
 							components={{
 								a: ({ node, href, children, ...props }) => {
-									if (href && href.includes("github.com")) {
+									let isGitHubLink = false;
+
+									if (href) {
+										try {
+											const parsedUrl = new URL(href, window.location.origin);
+											const host = parsedUrl.hostname.toLowerCase();
+											isGitHubLink = host === "github.com" || host.endsWith(".github.com");
+										} catch (error) {
+											isGitHubLink = false;
+										}
+									}
+
+									if (isGitHubLink) {
 										return <ButtonContained text={children} linkTo={href} />;
 									}
 									return (


### PR DESCRIPTION
Potential fix for [https://github.com/smswithoutborders/RelaySMS-Website/security/code-scanning/4](https://github.com/smswithoutborders/RelaySMS-Website/security/code-scanning/4)

Use URL parsing and hostname validation instead of substring matching.

Best fix in this file: in `src/Pages/Overview.jsx`, inside the custom markdown `a` renderer (around line 146–149), replace `href.includes("github.com")` with logic that:

1. Safely parses `href` via `new URL(href, window.location.origin)` (supports absolute and relative URLs),
2. Extracts `parsedUrl.hostname` in lowercase,
3. Treats as GitHub only when hostname is exactly `github.com` or a subdomain ending with `.github.com`,
4. Falls back safely if parsing fails.

No new dependencies are needed; this uses built-in browser `URL`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
